### PR TITLE
add shared advisory locks

### DIFF
--- a/lib/sequel/extensions/pg_advisory_lock.rb
+++ b/lib/sequel/extensions/pg_advisory_lock.rb
@@ -7,18 +7,27 @@ module Sequel
 
       SESSION_LEVEL_LOCKS = [
         :pg_advisory_lock,
-        :pg_try_advisory_lock
+        :pg_try_advisory_lock,
+        :pg_advisory_lock_shared,
+        :pg_try_advisory_lock_shared
       ].freeze
 
       TRANSACTION_LEVEL_LOCKS = [
         :pg_advisory_xact_lock,
-        :pg_try_advisory_xact_lock
+        :pg_try_advisory_xact_lock,
+        :pg_advisory_xact_lock_shared,
+        :pg_try_advisory_xact_lock_shared
       ].freeze
 
       LOCK_FUNCTIONS = (SESSION_LEVEL_LOCKS + TRANSACTION_LEVEL_LOCKS).freeze
 
       DEFAULT_LOCK_FUNCTION = :pg_advisory_lock
-      UNLOCK_FUNCTION = :pg_advisory_unlock
+      UNLOCK_FUNCTIONS = {
+        pg_advisory_lock: :pg_advisory_unlock,
+        pg_try_advisory_lock: :pg_advisory_unlock,
+        pg_advisory_lock_shared: :pg_advisory_unlock_shared,
+        pg_try_advisory_lock_shared: :pg_advisory_unlock_shared
+      }.freeze
 
       def registered_advisory_locks
         @registered_advisory_locks ||= {}
@@ -50,7 +59,7 @@ module Sequel
               begin
                 result = yield
               ensure
-                get(Sequel.function(UNLOCK_FUNCTION, *function_params))
+                get(Sequel.function(UNLOCK_FUNCTIONS[lock_function], *function_params))
                 result
               end
             end

--- a/test/register_advisory_lock_test.rb
+++ b/test/register_advisory_lock_test.rb
@@ -8,8 +8,12 @@ describe Sequel::Postgres::PgAdvisoryLock do
       [
         :pg_advisory_lock,
         :pg_try_advisory_lock,
+        :pg_advisory_lock_shared,
+        :pg_try_advisory_lock_shared,
         :pg_advisory_xact_lock,
-        :pg_try_advisory_xact_lock
+        :pg_try_advisory_xact_lock,
+        :pg_advisory_xact_lock_shared,
+        :pg_try_advisory_xact_lock_shared
       ]
     end
 


### PR DESCRIPTION
This library does not include shared locks, which are [another form](https://www.postgresql.org/docs/9.6/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS) of postgres advisory lock. I added them.

It didn't seem like any new tests were needed, but let me know if you want me to write some.

Thanks!